### PR TITLE
Bugfixes for behavior when checksum caching is disabled

### DIFF
--- a/lib/cacheBuster.js
+++ b/lib/cacheBuster.js
@@ -35,7 +35,7 @@ module.exports = function (baseDirs, useCachedChecksums) {
       return checksums[fileName];
     },
     validateChecksumMiddleware: function () {
-      return validateChecksumMiddleware(checksums);
+      return validateChecksumMiddleware(checksums, useCachedChecksums);
     }
   };
 

--- a/lib/validateChecksumMiddleware.js
+++ b/lib/validateChecksumMiddleware.js
@@ -1,7 +1,7 @@
 "use strict";
 var onHeaders = require("on-headers");
 
-function validateChecksumMiddleware(checksums) {
+function validateChecksumMiddleware(checksums, useCachedChecksums) {
   return function (req, res, next) {
     onHeaders(res, function () {
       var fileName = req.path;
@@ -11,7 +11,7 @@ function validateChecksumMiddleware(checksums) {
         fileName = fileName.substr(1);
       }
 
-      if (clientChecksum && checksums[fileName] !== clientChecksum) {
+      if (useCachedChecksums && clientChecksum && checksums[fileName] !== clientChecksum) {
         res.set("Cache-Control", "no-cache, no-store, must-revalidate");
         res.set("Edge-control", "no-store");
         res.set("Pragma", "no-cache");

--- a/test/validateChecksumMiddlewareTest.js
+++ b/test/validateChecksumMiddlewareTest.js
@@ -30,6 +30,27 @@ describe("ValidateChecksumMiddleware", function () {
     cacheBuster = require("../")(["tmp"]);
   });
 
+  describe("without caching", function() {
+    beforeEach(function () {
+      cacheBuster = require("../")(["tmp"], false);
+      middleware = cacheBuster.validateChecksumMiddleware(checksums);
+    });
+
+    it ("returns headers for caching if checksum is correct", function(done) {
+      var server = express();
+      server.use(middleware);
+      server.get(tmpFileName, function (req, res) {
+        res.set("Cache-Control", "public, max-age=100");
+        res.sendFile(tmpFilePath);
+      });
+
+      request(server)
+          .get(tmpFileName + "?c=" + tmpFileChecksum)
+          .expect("Cache-Control", "public, max-age=100")
+          .expect(200, done);
+    });
+  });
+
   describe("Changes Cache-Control header", function () {
     it("sets the Cache-Control header to no-cache when checksums doesn't match", function (done) {
       var server = express();

--- a/test/validateChecksumMiddlewareTest.js
+++ b/test/validateChecksumMiddlewareTest.js
@@ -30,15 +30,17 @@ describe("ValidateChecksumMiddleware", function () {
     cacheBuster = require("../")(["tmp"]);
   });
 
-  describe("without caching", function() {
+  describe("without checksum caching", function() {
+    var cacheBusterWithoutCaching;
+
     beforeEach(function () {
-      cacheBuster = require("../")(["tmp"], false);
-      middleware = cacheBuster.validateChecksumMiddleware(checksums);
+      cacheBusterWithoutCaching = require("../")(["tmp"], false);
+      cacheBusterWithoutCaching.bust(tmpFileName);
     });
 
     it ("returns headers for caching if checksum is correct", function(done) {
       var server = express();
-      server.use(middleware);
+      server.use(cacheBusterWithoutCaching.validateChecksumMiddleware());
       server.get(tmpFileName, function (req, res) {
         res.set("Cache-Control", "public, max-age=100");
         res.sendFile(tmpFilePath);
@@ -51,8 +53,8 @@ describe("ValidateChecksumMiddleware", function () {
     });
   });
 
-  describe("Changes Cache-Control header", function () {
-    it("sets the Cache-Control header to no-cache when checksums doesn't match", function (done) {
+  describe("Sets the Cache-Control header to no-cache", function () {
+    it("when checksums doesn't match", function (done) {
       var server = express();
       server.use(middleware);
       server.get(tmpFileName, function (req, res) {
@@ -70,7 +72,7 @@ describe("ValidateChecksumMiddleware", function () {
         .expect(200, done);
     });
 
-    it("sets the Cache-Control header to no-cache when the requested checksum is not found", function (done) {
+    it("when the requested checksum is not found", function (done) {
       var server = express();
       server.use(middleware);
       server.get("/missing-file?c=probably-valid-checksum", function (req, res) {
@@ -89,8 +91,8 @@ describe("ValidateChecksumMiddleware", function () {
     });
   });
 
-  describe("Doesn't changes Cache-Control header", function () {
-    it("does nothing to Cache-Control header when checksum matches", function (done) {
+  describe("doesn't change Cache-Control header", function () {
+    it("when checksum matches", function (done) {
       var server = express();
       server.use(middleware);
       server.get(tmpFileName, function (req, res) {
@@ -104,7 +106,7 @@ describe("ValidateChecksumMiddleware", function () {
         .expect(200, done);
     });
 
-    it("does nothing to the Cache-Control header when query parameter c is missing", function (done) {
+    it("when query parameter c is missing", function (done) {
       var server = express();
       server.use(middleware);
       server.get(tmpFileName, function (req, res) {


### PR DESCRIPTION
Cache-control is always set to "no-cache, no-store, must-revalidate" when checksum caching is disabled. This PR fixes that.